### PR TITLE
feat: Impliment tweet cache

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,8 +2,10 @@ var Twitter = require('twitter');
 var Promise = require('bluebird');
 var htmlEndecode = require('./htmlEndecode');
 
+var tweet_cache = {};
+
 var requireTweet = function(tweet_id) {
- 
+
     var client = new Twitter({
         consumer_key: 'ARWRCaE9xeUkVq5T4ZZPxmIST',
         consumer_secret: 'AgPnR8EVZHITvGxA0yZ4UPnmVPrBTFSH59L2eq8X1jl0avaNHe',
@@ -12,11 +14,14 @@ var requireTweet = function(tweet_id) {
     });
 
     return new Promise(function (resolve, reject) {
+        if (tweet_cache[tweet_id]) return resolve(tweet_cache[tweet_id]);
+
         client.get('statuses/show', {
             id: tweet_id
         }, function(error, tweet, response) {
             if (error) reject(response);
             eval("var module = " + htmlEndecode.htmlDecode(tweet.text));
+            tweet_cache[tweet_id] = module;
             resolve(module);
         })
     });


### PR DESCRIPTION
Once a tweet has been required once, there's no need to look up the tweet again. Implementing a cache allows the code to run faster and mimics what a native require does. 
